### PR TITLE
Replace 'true/punycode' with 'symfony/polyfill-intl-idn'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Middleware to block referrer spammers using [matomo/referrer-spam-blacklist](htt
 * PHP >= 7.2
 * A [PSR-7 http library](https://github.com/middlewares/awesome-psr15-middlewares#psr-7-implementations)
 * A [PSR-15 middleware dispatcher](https://github.com/middlewares/awesome-psr15-middlewares#dispatcher)
-* `ext-intl` PHP extension or [true/punycode](https://github.com/true/php-punycode) as alternative
+
+`ext-intl` PHP extension is recommended otherwise [symfony/polyfill-intl-idn](https://github.com/symfony/polyfill-intl-idn) is used. 
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         "php": "^7.2 || ^8.0",
         "middlewares/utils": "^3.0",
         "matomo/referrer-spam-blacklist": "*",
-        "psr/http-server-middleware": "^1.0"
+        "psr/http-server-middleware": "^1.0",
+        "symfony/polyfill-intl-idn": "^1.26"
     },
     "suggest": {
-        "true/punycode": "~2.0",
         "ext-intl": "*"
     },
     "require-dev": {
@@ -33,7 +33,6 @@
         "friendsofphp/php-cs-fixer": "^2.0",
         "squizlabs/php_codesniffer": "^3.0",
         "oscarotero/php-cs-fixer-config": "^1.0",
-        "true/punycode": "^2.1",
         "phpstan/phpstan": "^0.12"
     },
     "autoload": {

--- a/src/ReferrerSpam.php
+++ b/src/ReferrerSpam.php
@@ -28,9 +28,9 @@ class ReferrerSpam implements MiddlewareInterface
      */
     private static function checkIDNtoASCII()
     {
-        if (!function_exists('idn_to_ascii') && !method_exists('\TrueBV\Punycode', 'encode')) {
+        if (!function_exists('idn_to_ascii')) {
             throw new RuntimeException(
-                "To handle Unicode encoded domain name, Intl PHP extension or the lib 'true/punycode' is required"
+                "To handle Unicode encoded domain name, Intl PHP extension"
             );
         }
     }
@@ -67,7 +67,7 @@ class ReferrerSpam implements MiddlewareInterface
                 $host = urldecode($host);
                 $host = preg_replace('/^(www\.)/i', '', $host);
                 $host = $this->encodeIDN($host);
-    
+
                 if (in_array($host, $this->blackList, true)) {
                     return $this->responseFactory->createResponse(403);
                 }
@@ -82,11 +82,7 @@ class ReferrerSpam implements MiddlewareInterface
      */
     private function encodeIDN(string $domain): string
     {
-        if (function_exists('idn_to_ascii')) {
-            return idn_to_ascii($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46) ?: $domain;
-        }
-
-        return (new \TrueBV\Punycode())->encode($domain);
+        return idn_to_ascii($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46) ?: $domain;
     }
 
     /**


### PR DESCRIPTION
[true/punycode](https://github.com/true/php-punycode) is abandoned and they suggested that if there is need [symfony/polyfill-intl-idn](https://github.com/symfony/polyfill-intl-idn) should be used instead. So, this fix that.